### PR TITLE
support opening mesh on different drive than mesh viewer.

### DIFF
--- a/ogre-meshviewer.bat
+++ b/ogre-meshviewer.bat
@@ -1,3 +1,3 @@
-cd %~dp0
+cd /d %~dp0
 python ogre_mesh_viewer.py %1
 if errorlevel 1 pause


### PR DESCRIPTION
if the batch file is on a different drive than the target '.mesh' file the viewer will fail to open.

the change directory command needs to include /d to *also* change drive letters.