### PR TITLE
Add shebang to mesh viewer

### DIFF
--- a/ogre_mesh_viewer.py
+++ b/ogre_mesh_viewer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import Ogre
 import Ogre.RTShader as OgreRTShader
 import Ogre.Bites as OgreBites


### PR DESCRIPTION
The python script `ogre_mesh_viewer.py` is missing the shebang, which creates a situation where naively executing the script from command line creates problems.

It is usually expected that one can do:
```
./ogre_mesh_viewer.py infile
```
