### PR TITLE
Set YawPitchDist to initial values

### DIFF
--- a/ogre_mesh_viewer.py
+++ b/ogre_mesh_viewer.py
@@ -780,6 +780,8 @@ class MeshViewer(OgreBites.ApplicationContext, OgreBites.InputListener):
         self.camman = OgreBites.CameraMan(camnode)
         self.camman.setStyle(OgreBites.CS_ORBIT)
 
+        # We need to set YawPitchDist to initial values, so "diam" is properly set
+        self.camman.setYawPitchDist(0, self.default_tilt, diam)
         self.update_fixed_camera_yaw()
 
         self.input_dispatcher = OgreBites.InputListenerChain([self.getImGuiInputListener(), self.camman, self])


### PR DESCRIPTION
It is true that we are calling `setYawPitchDist()` twice, but it is necessary to set an initial value of the camera distance and also it is only the first time.

The `diam` is computed from the bounding box of the object so that it is at a proper distance.